### PR TITLE
Fix typo beacon-project website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ The Beacon protocol defines an open standard for genomics data discovery, develo
 
 This repository contains the specification for the *v2* major version upgrade of the Beacon API. It is now (2020) under active development and has _not_ seen a _stable_ code release.
 
-For further information, please follow the work here and consult the [Beacon Project website](http://bacon-project.io).
+For further information, please follow the work here and consult the [Beacon Project website](http://beacon-project.io).


### PR DESCRIPTION
small typo on the project website.
This should fix the link.