### PR TITLE
Tag missing descriptions with TBD

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1340,7 +1340,7 @@ components:
         - $ref: '#/components/schemas/AlternativeSchema'
     VariantReponseResults:
       description: |
-        Description pending
+        TBD
       properties:
         variant:
           $ref: '#/components/schemas/Variant'
@@ -1400,7 +1400,7 @@ components:
           $ref: '#/components/schemas/RequestQuery'
     RequestQuery:
       description: |
-        Description pending
+        TBD
       type: object
       properties:
         individual:
@@ -1666,7 +1666,7 @@ components:
 
     GenomicVariantResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - exists
@@ -1700,7 +1700,7 @@ components:
 
     # IndividualRequest:
     #   description: |
-    #     Description pending
+    #     TBD
     #   type: object
     #   required:
     #     - meta
@@ -1724,7 +1724,7 @@ components:
           $ref: '#/components/schemas/IndividualResponseContent'
     IndividualResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - exists
@@ -1762,7 +1762,7 @@ components:
 
     # BiosampleRequest:
     #   description: |
-    #     Description pending
+    #     TBD
     #   type: object
     #   required:
     #     - meta
@@ -1786,7 +1786,7 @@ components:
           $ref: '#/components/schemas/BiosampleResponseContent'
     BiosampleResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - exists
@@ -1839,7 +1839,7 @@ components:
           $ref: '#/components/schemas/RunResponseContent'
     RunResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - exists
@@ -1892,7 +1892,7 @@ components:
           $ref: '#/components/schemas/AnalysisResponseContent'
     AnalysisResponseContent:
       description: |
-        TODO
+        TBD
       type: object
       required:
         - exists
@@ -1945,7 +1945,7 @@ components:
           $ref: '#/components/schemas/VariantInSampleResponseContent'
     VariantInSampleResponseContent:
       description: |
-        TODO
+        TBD
       type: object
       required:
         - exists
@@ -1998,7 +1998,7 @@ components:
           $ref: '#/components/schemas/VariantInterpretationResponseContent'
     VariantInterpretationResponseContent:
       description: |
-        TODO
+        TBD
       type: object
       required:
         - exists
@@ -2051,7 +2051,7 @@ components:
           $ref: '#/components/schemas/InteractorResponseContent'
     InteractorResponseContent:
       description: |
-        TODO
+        TBD
       type: object
       required:
         - exists
@@ -2103,7 +2103,7 @@ components:
           $ref: '#/components/schemas/CohortResponseContent'
     CohortResponseContent:
       description: |
-        TODO
+        TBD
       type: object
       required:
         - exists
@@ -2164,7 +2164,7 @@ components:
             - $ref: '#/components/schemas/FilteringTermResponseContent'
     InfoResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - results
@@ -2187,7 +2187,7 @@ components:
 
     DatasetResponseContent:
       description: |
-        Description pending
+        TBD
       type: object
       required:
         - results
@@ -2419,7 +2419,7 @@ components:
         datasetId:
           type: string
           description: |
-            not provided
+            `id` of the dataset.
         exists:
           description: >-
             Indicator of whether the given allele was observed in the dataset.


### PR DESCRIPTION
Tag missing descriptions with TBD, so they can easily be searched and filled.

Then, somebody should review and complete them.