### PR TITLE
variantMinLength and variantMaxLength

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1511,6 +1511,28 @@ components:
             Either `alternateBases` or `variantType` is required, with the
             exception of range queries (single `start` and `end` parameters).
           type: string
+        variantMinLength:
+          description: >
+            Minimum length in bases of a genomic variant. This is an optional
+            parameter without prescribed use. While a length is commonly available
+            for structural variants such as copy number variations, it is
+            recommended that length based queries should also be supported for
+            variants with indicated referenceBases and alternateBases, to enable
+            length-specific wildcard queries.
+          type: integer
+            format: int64
+            minimum: 0
+        variantMaxLength:
+          description: >
+            Maximum length in bases of a genomic variant. This is an optional
+            parameter without prescribed use. While a length is commonly available
+            for structural variants such as copy number variations, it is
+            recommended that length based queries should also be supported for
+            variants with indicated referenceBases and alternateBases, to enable
+            length-specific wildcard queries.
+          type: integer
+            format: int64
+            minimum: 1
         mateName:
           $ref: '#/components/schemas/Chromosome'
     IndividualFields:


### PR DESCRIPTION
This PR introduces additional, optional variant query parameters which have been identified by the Beacon Variant Scout Team to enable new types of variant queries. Examples would be here e.g. "a deletion of at least 10bp in the 5` region of a gene", where the genomic region can be scoped through a range or bracket query, but the size cannot.