### PR TITLE
Add support for IUPAC nucleotide codes (#23)

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1177,30 +1177,22 @@ components:
     ReferenceBases:
       description: >
         Reference bases for this variant (starting from `start`).
-        * Accepted values: [ACGTN]*.
-        * N is a wildcard, that denotes the position of any base, and can be
-        used as a standalone base of any type or within a partially known
-        sequence. As example, a query of `ANNT` the Ns can take take any form of
-        [ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.
-        * an *empty value* is used in the case of insertions with the maximally
-        trimmed, inserted sequence being indicated in `AlternateBases`
+        * Accepted values: [ACGTRYSWKMBDHVN\.-]*.
+        * IUPAC nucleotide codes are supported.
       type: string
-      pattern: '^([ACGTN]*)$'
+      pattern: '^([ACGTRYSWKMBDHVN\.-]*)$'
     AlternateBases:
       description: |
         Alternate bases for this variant (starting from `start`).
-        * Accepted values: [ACGTN]*.
-        * N is a wildcard, that denotes the position of any base, and can be
-        used as a standalone base of any type or within a partially known
-        sequence. As example, a query of `ANNT` the Ns can take take any form of
-        [ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.
+        * Accepted values: [ACGTRYSWKMBDHVN\.-]*.
+        * IUPAC nucleotide codes are supported.
         * an *empty value* is used in the case of deletions with the maximally
         trimmed, deleted sequence being indicated in `ReferenceBases`
         * Categorical variant queries, e.g. such *not* being represented through
         sequence & position, make use of the `variantType` parameter.
         * either `alternateBases` or `variantType` is required.
       type: string
-      pattern: '^([ACGTN]*)$'
+      pattern: '^([ACGTRYSWKMBDHVN\.-]*)$'
     Filters:
       description: |
         Ontology based filters. CURIE syntax is encouraged to be used.
@@ -1520,8 +1512,8 @@ components:
             variants with indicated referenceBases and alternateBases, to enable
             length-specific wildcard queries.
           type: integer
-            format: int64
-            minimum: 0
+          format: int64
+          minimum: 0
         variantMaxLength:
           description: >
             Maximum length in bases of a genomic variant. This is an optional
@@ -1531,8 +1523,8 @@ components:
             variants with indicated referenceBases and alternateBases, to enable
             length-specific wildcard queries.
           type: integer
-            format: int64
-            minimum: 1
+          format: int64
+          minimum: 1
         mateName:
           $ref: '#/components/schemas/Chromosome'
     IndividualFields:


### PR DESCRIPTION
Somebody should review the description of `referenceBases` and `alternateBases` fields: @mbaudis, @jrambla, @antbro.