### PR TITLE
Fix inconsistency in properties names (#54)

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1245,14 +1245,14 @@ components:
         Format of the response.
       type: object
       properties:
-        Info:
+        info:
           type: string
           example: 'beacon-info-v2.0.0-draft.3'
-        Dataset:
+        dataset:
           type: string
           example:
             'beacon-dataset-v2.0.0-draft.3'
-        FilterTerm:
+        filterTerm:
           type: string
           example:
             'beacon-filtering-term-v2.0.0-draft.3'
@@ -1261,35 +1261,35 @@ components:
         Format of the responses and version of the Beacon handling this request.
       type: object
       properties:
-        VariantIdentification:
+        variantIdentification:
           type: string
           example:
             ga4gh-variant-representation-v0.1
-        VariantAnnotation:
+        variantAnnotation:
           type: string
           example: beacon-variant-annotation-draft-2
-        Individual:
+        individual:
           type: string
           example: ga4gh-phenopacket-individual-v0.1
-        Biosample:
+        biosample:
           type: string
           example: ga4gh-schemablocks-biosample-v0.1
-        Run:
+        run:
           type: string
           example: beacon-run-draft-3
-        Analysis:
+        analysis:
           type: string
           example: beacon-analysis-draft-2
-        VariantInSample:
+        variantInSample:
           type: string
           example: beacon-variant-in-sample-draft-3
-        VariantInterpretation:
+        variantInterpretation:
           type: string
           example: beacon-variant-interpretation-draft-2
-        Interactor:
+        interactor:
           type: string
           example: beacon-interactor-draft-2
-        Cohort:
+        cohort:
           type: string
           example: beacon-cohort-draft-3
     InfoRequestMeta:

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1520,8 +1520,8 @@ components:
             variants with indicated referenceBases and alternateBases, to enable
             length-specific wildcard queries.
           type: integer
-            format: int64
-            minimum: 0
+          format: int64
+          minimum: 0
         variantMaxLength:
           description: >
             Maximum length in bases of a genomic variant. This is an optional
@@ -1531,8 +1531,8 @@ components:
             variants with indicated referenceBases and alternateBases, to enable
             length-specific wildcard queries.
           type: integer
-            format: int64
-            minimum: 1
+          format: int64
+          minimum: 1
         mateName:
           $ref: '#/components/schemas/Chromosome'
     IndividualFields:

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1252,7 +1252,7 @@ components:
           type: string
           example:
             'beacon-dataset-v2.0.0-draft.3'
-        filterTerm:
+        filteringTerm:
           type: string
           example:
             'beacon-filtering-term-v2.0.0-draft.3'


### PR DESCRIPTION
They should start with lowercase to keep consistency among all properties.